### PR TITLE
Add `configobj` to requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
+configobj>=5.0.0
 numpy>=1.12.0rc2
 pandas>=0.19.2
 scipy>=0.18.1


### PR DESCRIPTION
The dependency `configobj` was missing from the `requirements.txt` file.  This has now been added.

Fixes #15 