### PR TITLE
Install gcamreader from pip

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -31,7 +31,7 @@ jobs:
             pip install pandas==1.2.4
             pip install scipy==1.6.3
             pip install requests==2.25.1
-            pip install git+https://github.com/JGCRI/gcam_reader.git
+            pip install git+https://github.com/JGCRI/gcamreader.git
 
         - name: Test and generate coverage report
           run: |

--- a/Dockerfile
+++ b/Dockerfile
@@ -11,7 +11,7 @@ WORKDIR /code
 
 # install dependencies
 RUN pip install --upgrade pip \
-    && pip install git+https://github.com/JGCRI/gcam_reader.git \
+    && pip install gcamreader \
     && pip install --trusted-host pypi.python.org --requirement requirements.txt
 
 # copy package

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ Demeter is an open source Python package that was built to disaggregate projecti
 Set up Demeter using the following steps:
 1.  Install Demeter from GitHub:
     ```bash
-    python -m pip install -e git+http://github.com/JGCRI/demeter.git#egg=demeter
+    python -m pip install git+http://github.com/JGCRI/demeter.git#egg=demeter
     ```
 2.  Download the example data using the following in a Python prompt:
     ```python

--- a/README.md
+++ b/README.md
@@ -8,9 +8,9 @@ Demeter is an open source Python package that was built to disaggregate projecti
 
 # Getting Started with Demeter
 Set up Demeter using the following steps:
-1.  Install Demeter using pip:
+1.  Install Demeter from GitHub:
     ```bash
-    pip install demeter
+    python -m pip install -e git+http://github.com/JGCRI/demeter.git#egg=demeter
     ```
 2.  Download the example data using the following in a Python prompt:
     ```python

--- a/README.md
+++ b/README.md
@@ -8,9 +8,9 @@ Demeter is an open source Python package that was built to disaggregate projecti
 
 # Getting Started with Demeter
 Set up Demeter using the following steps:
-1.  Install Demeter from GitHub using:
+1.  Install Demeter using pip:
     ```bash
-    python -m pip install git+https://github.com/JGCRI/demeter.git
+    pip install demeter
     ```
 2.  Download the example data using the following in a Python prompt:
     ```python

--- a/demeter/demeter_io/reader.py
+++ b/demeter/demeter_io/reader.py
@@ -14,7 +14,7 @@ import logging
 
 import numpy as np
 import pandas as pd
-import gcam_reader
+import gcamreader
 
 
 class ValidationException(Exception):
@@ -207,17 +207,17 @@ def read_gcam_land(db_path, db_file, f_queries, d_basin_name, subreg, crop_water
     """
 
     # instantiate GCAM db
-    conn = gcam_reader.LocalDBConn(db_path, db_file, suppress_gabble=False)
+    conn = gcamreader.LocalDBConn(db_path, db_file, suppress_gabble=False)
 
     # get queries
-    q = gcam_reader.parse_batch_query(f_queries)
+    q = gcamreader.parse_batch_query(f_queries)
 
     # assume target query is first in query list
     land_alloc = conn.runQuery(q[0])
 
     # split 'land-allocation' column into components
     if subreg == 'AEZ':
-        raise ValueError("Using AEZs are no longer supported with `gcam_reader`")
+        raise ValueError("Using AEZs are no longer supported with `gcamreader`")
 
     elif subreg == 'BASIN':
         # expected format: landclass_basin-glu-name_USE_management
@@ -260,7 +260,7 @@ def read_gcam_file(gcam_data, gcam_landclasses, start_yr, end_yr, timestep, scen
     """
     Read and process the GCAM land allocation output file.
 
-    :param gcam_data:           GCAM land allocation file or data frame from gcam_reader
+    :param gcam_data:           GCAM land allocation file or data frame from gcamreader
     :param name_col:            Field name of the column containing the region and either AEZ or basin number
     :param metric:              AEZ or Basin
     :param start_yr:            User-defined GCAM start year to process from configuration file

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,6 @@
+configobj~=5.0.6
+numpy~=1.20.3
+pandas~=1.2.4
+scipy~=1.6.3
+requests~=2.20.0
+gcamreader~=1.2.4

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,0 +1,2 @@
+[metadata]
+description_file = README.md

--- a/setup.py
+++ b/setup.py
@@ -2,28 +2,28 @@ from setuptools import setup, find_packages
 
 
 def readme():
+    """Return the contents of the project README file."""
     with open('README.md') as f:
         return f.read()
 
 
 setup(
     name='demeter',
-    version='1.2.0',
+    version='1.2.1',
     python_requires=">=3.6",
     packages=find_packages(),
-    url='https://github.com/IMMM-SFA/demeter',
+    url='https://github.com/JGCRI/demeter',
     license='BSD 2-Clause',
-    author='Chris R. Vernon; Yannick le Page; Caleb Braun',
+    author='Chris R. Vernon',
     author_email='chris.vernon@pnnl.gov',
-    description='A land use land cover disaggregation and land change analytic model',
+    description='A land use land cover change disaggregation model',
     long_description=readme(),
     long_description_content_type="text/markdown",
-    install_requires=['configobj==5.0.6',
-                      'numpy==1.20.3',
-                      'pandas==1.2.4',
-                      'scipy==1.6.3',
-                      'requests==2.25.1',
-                      'gcam_reader==1.2.0'],
-    dependency_links=['git+https://github.com/JGCRI/gcam_reader@master#egg=gcam_reader-1.2.0'],
+    install_requires=['configobj~=5.0.6',
+                      'numpy~=1.20.3',
+                      'pandas~=1.2.4',
+                      'scipy~=1.6.3',
+                      'requests~=2.20.0',
+                      'gcamreader~=1.2.4'],
     include_package_data=True
 )


### PR DESCRIPTION
Change protocol to install `gcamreader` from pip instead of having a GitHub install dependency.