### PR TITLE
Update install_supplement.py

### DIFF
--- a/demeter/install_supplement.py
+++ b/demeter/install_supplement.py
@@ -16,7 +16,8 @@ class InstallSupplement:
     """
 
     # URL for DOI minted example data hosted on Zenodo
-    DATA_VERSION_URLS = {'1.3.1': 'https://zenodo.org/record/7240315/files/config_gcam_reference.zip?download=1'}
+    DATA_VERSION_URLS = {'1.3.1': 'https://zenodo.org/record/7240315/files/config_gcam_reference.zip?download=1',
+                        '2.0.0': 'https://zenodo.org/record/7240315/files/config_gcam_reference.zip?download=1'}
 
     def __init__(self, example_data_directory):
 


### PR DESCRIPTION
update pointer to data for version 2.0.0 in https://github.com/JGCRI/demeter/blob/1bb5d981d97d9c6d87521df3aabf80363ab81276/demeter/install_supplement.py#L19. Currently points to the same data as 1.3.1. fixes #40 